### PR TITLE
 Implement CRUD operations for Items and establish relationship with PackingList

### DIFF
--- a/lib/phx_packing_list/packing.ex
+++ b/lib/phx_packing_list/packing.ex
@@ -131,7 +131,13 @@ defmodule PhxPackingList.Packing do
       ** (Ecto.NoResultsError)
 
   """
-  def get_item!(id), do: Repo.get!(Item, id)
+  def get_item!(packing_list_id, id) do
+    PackingList
+    |> Repo.get!(packing_list_id)
+    |> Repo.preload(:items)
+    |> Map.get(:items)
+    |> Enum.find(&(&1.id == String.to_integer(id)))
+  end
 
   @doc """
   Creates a item.
@@ -145,8 +151,10 @@ defmodule PhxPackingList.Packing do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_item(attrs \\ %{}) do
-    %Item{}
+  def create_item(packing_list_id, attrs \\ %{}) do
+    packing_list = Repo.get!(PackingList, packing_list_id)
+
+    Ecto.build_assoc(packing_list, :items, attrs)
     |> Item.changeset(attrs)
     |> Repo.insert()
   end
@@ -196,5 +204,9 @@ defmodule PhxPackingList.Packing do
   """
   def change_item(%Item{} = item, attrs \\ %{}) do
     Item.changeset(item, attrs)
+  end
+
+  def list_items_for_packing_list(packing_list_id) do
+    Repo.all(from i in Item, where: i.packing_list_id == ^packing_list_id)
   end
 end

--- a/lib/phx_packing_list/packing/item.ex
+++ b/lib/phx_packing_list/packing/item.ex
@@ -6,7 +6,7 @@ defmodule PhxPackingList.Packing.Item do
     field :name, :string
     field :notes, :string
     field :quantity, :integer
-    field :packing_list_id, :id
+    belongs_to :packing_list, PhxPackingList.Packing.PackingList
 
     timestamps()
   end

--- a/lib/phx_packing_list/packing/packing_list.ex
+++ b/lib/phx_packing_list/packing/packing_list.ex
@@ -8,6 +8,8 @@ defmodule PhxPackingList.Packing.PackingList do
     field :start_date, :date
     field :end_date, :date
     field :travel_destination, :string
+    has_many :items, PhxPackingList.Packing.Item
+
     timestamps()
   end
 

--- a/lib/phx_packing_list_web/controllers/item_controller.ex
+++ b/lib/phx_packing_list_web/controllers/item_controller.ex
@@ -4,59 +4,60 @@ defmodule PhxPackingListWeb.ItemController do
   alias PhxPackingList.Packing
   alias PhxPackingList.Packing.Item
 
-  def index(conn, _params) do
-    items = Packing.list_items()
-    render(conn, :index, items: items)
+  def index(conn, %{"packing_list_id" => packing_list_id}) do
+    items = Packing.list_items_for_packing_list(packing_list_id)
+    render(conn, :index, items: items, packing_list_id: packing_list_id)
   end
 
-  def new(conn, _params) do
+  def new(conn, %{"packing_list_id" => packing_list_id}) do
     changeset = Packing.change_item(%Item{})
-    render(conn, :new, changeset: changeset)
+    render(conn, :new, changeset: changeset, packing_list_id: packing_list_id)
   end
 
-  def create(conn, %{"item" => item_params}) do
-    case Packing.create_item(item_params) do
-      {:ok, item} ->
+  def create(conn, %{"item" => item_params, "packing_list_id" => packing_list_id}) do
+    case Packing.create_item(packing_list_id, item_params) do
+      {:ok, _item} ->
         conn
         |> put_flash(:info, "Item created successfully.")
-        |> redirect(to: ~p"/items/#{item}")
+        |> redirect(to: ~p"/packing_lists/#{packing_list_id}/items/")
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :new, changeset: changeset)
+        render(conn, :new, changeset: changeset, packing_list_id: packing_list_id)
     end
   end
 
-  def show(conn, %{"id" => id}) do
-    item = Packing.get_item!(id)
+  def show(conn, %{"id" => id, "packing_list_id" => packing_list_id}) do
+    item = Packing.get_item!(packing_list_id, id)
     render(conn, :show, item: item)
   end
 
-  def edit(conn, %{"id" => id}) do
-    item = Packing.get_item!(id)
+  def edit(conn, %{"id" => id, "packing_list_id" => packing_list_id}) do
+    item = Packing.get_item!(packing_list_id, id)
     changeset = Packing.change_item(item)
-    render(conn, :edit, item: item, changeset: changeset)
+    render(conn, :edit, item: item, changeset: changeset, packing_list_id: packing_list_id)
   end
 
-  def update(conn, %{"id" => id, "item" => item_params}) do
-    item = Packing.get_item!(id)
+  def update(conn, %{"packing_list_id" => packing_list_id, "id" => id, "item" => item_params}) do
+
+    item = Packing.get_item!(packing_list_id, id)
 
     case Packing.update_item(item, item_params) do
-      {:ok, item} ->
+      {:ok, _item} ->
         conn
         |> put_flash(:info, "Item updated successfully.")
-        |> redirect(to: ~p"/items/#{item}")
+        |> redirect(to: ~p"/packing_lists/#{packing_list_id}/items/")
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, :edit, item: item, changeset: changeset)
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    item = Packing.get_item!(id)
+  def delete(conn, %{"packing_list_id" => packing_list_id, "id" => id}) do
+    item = Packing.get_item!(packing_list_id, id)
     {:ok, _item} = Packing.delete_item(item)
 
     conn
     |> put_flash(:info, "Item deleted successfully.")
-    |> redirect(to: ~p"/items")
+    |> redirect(to: ~p"/packing_lists/#{packing_list_id}/items")
   end
 end

--- a/lib/phx_packing_list_web/controllers/item_html/edit.html.heex
+++ b/lib/phx_packing_list_web/controllers/item_html/edit.html.heex
@@ -3,6 +3,6 @@
   <:subtitle>Use this form to manage item records in your database.</:subtitle>
 </.header>
 
-<.item_form changeset={@changeset} action={~p"/items/#{@item}"} />
+<.item_form changeset={@changeset} action={~p"/packing_lists/#{@packing_list_id}/items/#{@item}"} />
 
-<.back navigate={~p"/items"}>Back to items</.back>
+<.back navigate={~p"/packing_lists/#{@packing_list_id}/items"}>Back to items</.back>

--- a/lib/phx_packing_list_web/controllers/item_html/index.html.heex
+++ b/lib/phx_packing_list_web/controllers/item_html/index.html.heex
@@ -1,25 +1,27 @@
 <.header>
   Listing Items
   <:actions>
-    <.link href={~p"/items/new"}>
+    <.link href={~p"/packing_lists/#{@packing_list_id}/items/new/"}>
       <.button>New Item</.button>
     </.link>
   </:actions>
 </.header>
 
-<.table id="items" rows={@items} row_click={&JS.navigate(~p"/items/#{&1}")}>
+<.table id="items" rows={@items} row_click={&JS.navigate(~p"/packing_lists/#{@packing_list_id}/items/#{&1}")}>
   <:col :let={item} label="Name"><%= item.name %></:col>
   <:col :let={item} label="Quantity"><%= item.quantity %></:col>
   <:col :let={item} label="Notes"><%= item.notes %></:col>
   <:action :let={item}>
     <div class="sr-only">
-      <.link navigate={~p"/items/#{item}"}>Show</.link>
+      <.link navigate={~p"/packing_lists/#{@packing_list_id}/items/#{item}/edit"}>Edit</.link>
     </div>
-    <.link navigate={~p"/items/#{item}/edit"}>Edit</.link>
+    <.link navigate={~p"/packing_lists/#{@packing_list_id}/items/#{item}/edit"}>Edit</.link>
   </:action>
   <:action :let={item}>
-    <.link href={~p"/items/#{item}"} method="delete" data-confirm="Are you sure?">
+    <.link href={~p"/packing_lists/#{@packing_list_id}/items/#{item}"} method="delete" data-confirm="Are you sure?">
       Delete
     </.link>
   </:action>
 </.table>
+
+<.back navigate={~p"/packing_lists"}>Back to packing_lists</.back>

--- a/lib/phx_packing_list_web/controllers/item_html/new.html.heex
+++ b/lib/phx_packing_list_web/controllers/item_html/new.html.heex
@@ -3,6 +3,6 @@
   <:subtitle>Use this form to manage item records in your database.</:subtitle>
 </.header>
 
-<.item_form changeset={@changeset} action={~p"/items"} />
+<.item_form changeset={@changeset} action={~p"/packing_lists/#{@packing_list_id}/items"} />
 
-<.back navigate={~p"/items"}>Back to items</.back>
+<.back navigate={~p"/packing_lists/#{@packing_list_id}/items"}>Back to items</.back>

--- a/lib/phx_packing_list_web/controllers/packing_list_html/show.html.heex
+++ b/lib/phx_packing_list_web/controllers/packing_list_html/show.html.heex
@@ -5,6 +5,9 @@
     <.link href={~p"/packing_lists/#{@packing_list}/edit"}>
       <.button>Edit packing_list</.button>
     </.link>
+    <.link href={~p"/packing_lists/#{@packing_list}/items"}>
+      <.button>Manage Items</.button>
+    </.link>
   </:actions>
 </.header>
 

--- a/lib/phx_packing_list_web/router.ex
+++ b/lib/phx_packing_list_web/router.ex
@@ -18,7 +18,9 @@ defmodule PhxPackingListWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
-    resources "/packing_lists", PackingListController
+    resources "/packing_lists", PackingListController do
+      resources "/items", ItemController, only: [:index, :new, :create, :edit, :update, :delete]
+    end
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
**Description**
This pull request introduces the following changes to the Packing List Management App:
- Implements complete CRUD operations for Items schema.
- Adds a relationship between the PackingList and Items schemas.
- Adds helper functions in the context module to retrieve items associated with each packing list.
- Enhances the existing PackingList functionality to support the management of items within packing lists.

**Details**
- Before these changes, the app only supported editing metadata for packing lists. The Items schema was created, but CRUD operations for items were not fully implemented.
- This update enhances the app's functionality by enabling users to manage the items in each packing list.


<details>
<summary><strong>Screenshots</strong></summary>

<img width="986" alt="Screenshot 2023-05-09 at 5 39 45 AM" src="https://github.com/photon-collider/phx-packing-list/assets/50253017/6b55a4d1-0215-4c3c-b204-175dfa870507">

<img width="986" alt="Screenshot 2023-05-09 at 5 40 00 AM" src="https://github.com/photon-collider/phx-packing-list/assets/50253017/935bd979-0cb7-4bbe-b602-0c71efb4efd1">

<img width="986" alt="Screenshot 2023-05-09 at 5 40 10 AM" src="https://github.com/photon-collider/phx-packing-list/assets/50253017/58ace9ac-2263-4e0f-9987-5d88309e465f">

</details >
